### PR TITLE
Update Loader to support Task Handlers

### DIFF
--- a/lib/Traits/CanLoadInitializers.php
+++ b/lib/Traits/CanLoadInitializers.php
@@ -21,6 +21,9 @@ use PHPNomad\Mutator\Interfaces\HasMutations;
 use PHPNomad\Mutator\Interfaces\MutationStrategy;
 use PHPNomad\Rest\Interfaces\HasControllers;
 use PHPNomad\Rest\Interfaces\RestStrategy;
+use PHPNomad\Tasks\Interfaces\HasTaskHandlers;
+use PHPNomad\Tasks\Interfaces\Task;
+use PHPNomad\Tasks\Interfaces\TaskStrategy;
 use PHPNomad\Update\Events\UpgradeRoutinesRequested;
 use PHPNomad\Update\Interfaces\HasUpdates;
 use PHPNomad\Utils\Helpers\Arr;
@@ -29,14 +32,8 @@ trait CanLoadInitializers
 {
     protected InstanceProvider $container;
 
-    /**
-     * @var array[HasClassDefinitions|Loadable|HasLoadCondition|HasFacades|HasListeners|HasMutations|HasEventBindings]
-     */
     protected array $initializers = [];
 
-    /**
-     * @throws LoaderException
-     */
     protected function loadInitializers()
     {
         foreach ($this->initializers as $initializer) {
@@ -44,11 +41,6 @@ trait CanLoadInitializers
         }
     }
 
-    /**
-     * @param HasClassDefinitions|Loadable|HasLoadCondition|HasFacades|HasListeners|HasMutations|HasEventBindings|HasControllers $initializer
-     * @return void
-     * @throws LoaderException
-     */
     protected function loadInitializer($initializer): void
     {
         try {
@@ -56,7 +48,6 @@ trait CanLoadInitializers
                 $initializer->setContainer($this->container);
             }
 
-            // Bail early if this has a load condition preventing it from loading.
             if ($initializer instanceof HasLoadCondition && !$initializer->shouldLoad()) {
                 return;
             }
@@ -90,7 +81,6 @@ trait CanLoadInitializers
             }
 
             if ($initializer instanceof HasListeners) {
-                /** @var EventStrategy $instance */
                 $events = $this->container->get(EventStrategy::class);
 
                 foreach ($initializer->getListeners() as $event => $handlers) {
@@ -103,8 +93,19 @@ trait CanLoadInitializers
                 }
             }
 
+            if ($initializer instanceof HasTaskHandlers) {
+                $strategy = $this->container->get(TaskStrategy::class);
+
+                foreach ($initializer->getTaskHandlers() as $taskClass => $handlers) {
+                    foreach (Arr::wrap($handlers) as $handlerClass) {
+                        $strategy->attach($taskClass, fn(Task $task) =>
+                            $this->container->get($handlerClass)->handle($task)
+                        );
+                    }
+                }
+            }
+
             if ($initializer instanceof HasUpdates) {
-                /** @var EventStrategy $instance */
                 $events = $this->container->get(EventStrategy::class);
 
                 $events->attach(

--- a/lib/Traits/CanLoadInitializers.php
+++ b/lib/Traits/CanLoadInitializers.php
@@ -32,8 +32,15 @@ trait CanLoadInitializers
 {
     protected InstanceProvider $container;
 
+    /**
+     * @var array[HasClassDefinitions|Loadable|HasLoadCondition|HasFacades|HasListeners|HasMutations|HasEventBindings|HasTaskHandlers]
+     */
     protected array $initializers = [];
 
+    /**
+     * @return void
+     * @throws LoaderException
+     */
     protected function loadInitializers()
     {
         foreach ($this->initializers as $initializer) {


### PR DESCRIPTION
## Context

This PR adds support for the new `phpnomad/tasks` system by updating the `CanLoadInitializers` trait to recognize and process initializers that implement `HasTaskHandlers`.

The new task system introduced in `phpnomad/tasks v2.0.0` aligns closely with PHPNomad’s event architecture, allowing developers to define tasks as value objects and register one or more handlers to be executed in sequence. Like events, tasks are registered declaratively via initializers, and their dispatch logic is delegated to a platform-specific `TaskStrategy`.

## What Changed

* The loader now detects if an initializer implements `HasTaskHandlers`.
* When present, it retrieves the task-to-handler mappings and registers them with the active `TaskStrategy` instance via `attach()`.
* This mirrors how `HasListeners` is handled for events and supports multiple handlers per task class.

## Why This Matters

The addition ensures that the task system fully integrates with the PHPNomad bootstrap lifecycle and adheres to the same modular, initializer-driven design used throughout the framework.

By delegating handler registration to the loader:

* Integrations can cleanly register task pipelines without imperative code.
* The task system becomes first-class within PHPNomad.
* Dispatch and execution are decoupled from the application core, supporting immediate, queued, or deferred workflows depending on the configured strategy.

This update is necessary for any system adopting the new task architecture and completes the foundational work needed to support task execution across platforms like WordPress, Redis, or CLI.
